### PR TITLE
Adding inline keyword on (deprecated) solve_quadprog2 implemented in header

### DIFF
--- a/include/eiquadprog/eiquadprog.hpp
+++ b/include/eiquadprog/eiquadprog.hpp
@@ -120,7 +120,7 @@ double solve_quadprog(Eigen::LLT<Eigen::MatrixXd, Eigen::Lower> &chol,
                       Eigen::VectorXd &y, Eigen::VectorXi &A, size_t &q);
 
 EIQUADPROG_DEPRECATED
-double solve_quadprog2(Eigen::LLT<Eigen::MatrixXd, Eigen::Lower> &chol,
+inline double solve_quadprog2(Eigen::LLT<Eigen::MatrixXd, Eigen::Lower> &chol,
                        double c1, Eigen::VectorXd &g0,
                        const Eigen::MatrixXd &CE, const Eigen::VectorXd &ce0,
                        const Eigen::MatrixXd &CI, const Eigen::VectorXd &ci0,

--- a/include/eiquadprog/eiquadprog.hpp
+++ b/include/eiquadprog/eiquadprog.hpp
@@ -121,10 +121,12 @@ double solve_quadprog(Eigen::LLT<Eigen::MatrixXd, Eigen::Lower> &chol,
 
 EIQUADPROG_DEPRECATED
 inline double solve_quadprog2(Eigen::LLT<Eigen::MatrixXd, Eigen::Lower> &chol,
-                       double c1, Eigen::VectorXd &g0,
-                       const Eigen::MatrixXd &CE, const Eigen::VectorXd &ce0,
-                       const Eigen::MatrixXd &CI, const Eigen::VectorXd &ci0,
-                       Eigen::VectorXd &x, Eigen::VectorXi &A, size_t &q) {
+                              double c1, Eigen::VectorXd &g0,
+                              const Eigen::MatrixXd &CE,
+                              const Eigen::VectorXd &ce0,
+                              const Eigen::MatrixXd &CI,
+                              const Eigen::VectorXd &ci0, Eigen::VectorXd &x,
+                              Eigen::VectorXi &A, size_t &q) {
   return solve_quadprog(chol, c1, g0, CE, ce0, CI, ci0, x, A, q);
 }
 


### PR DESCRIPTION
Hello,
Since the deprecated `solve_quadprog2` is implemented in the header (forwarding its arguments to `solve_quadprog`), it should be marked `inline`, because else having multiple files including `eiquadprog.hpp` in the same project will result in a "multiple definition" error 