### PR TITLE
Ignore Wsign-conversion warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,8 @@ set(${PROJECT_NAME}_HEADERS
     include/${PROJECT_NAME}/eiquadprog-utils.hxx)
 
 add_library(${PROJECT_NAME} SHARED src/eiquadprog-fast.cpp src/eiquadprog.cpp)
-target_compile_options(${PROJECT_NAME} PRIVATE "-Wno-sign-conversion")  # We have a lot of implicit size_t to Eigen::Index conversions
+target_compile_options(${PROJECT_NAME} PRIVATE "-Wno-sign-conversion"
+)# We have a lot of implicit size_t to Eigen::Index conversions
 
 if(TRACE_SOLVER)
   target_compile_definitions(${PROJECT_NAME} PRIVATE EIQGUADPROG_TRACE_SOLVER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(${PROJECT_NAME}_HEADERS
     include/${PROJECT_NAME}/eiquadprog-utils.hxx)
 
 add_library(${PROJECT_NAME} SHARED src/eiquadprog-fast.cpp src/eiquadprog.cpp)
+target_compile_options(${PROJECT_NAME} PRIVATE "-Wno-sign-conversion")  # We have a lot of implicit size_t to Eigen::Index conversions
 
 if(TRACE_SOLVER)
   target_compile_definitions(${PROJECT_NAME} PRIVATE EIQGUADPROG_TRACE_SOLVER)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,10 +24,14 @@ set(TESTS eiquadprog-basic eiquadprog-fast eiquadprog-rt eiquadprog-both
 foreach(test ${TESTS})
   add_unit_test(${test} ${test}.cpp)
   target_link_libraries(${test} ${PROJECT_NAME} Boost::unit_test_framework)
-  target_compile_options(${test} PRIVATE "-Wno-sign-conversion")  # We have a lot of implicit size_t to Eigen::Index conversions
+  target_compile_options(
+    ${test} PRIVATE "-Wno-sign-conversion") # We have a lot of implicit size_t
+                                            # to Eigen::Index conversions
 endforeach(test ${TESTS})
 
 add_library(testab SHARED TestA.cpp TestB.cpp)
 target_link_libraries(testab ${PROJECT_NAME})
 target_link_libraries(test-integration testab)
-target_compile_options(testab PRIVATE "-Wno-sign-conversion")  # We have a lot of implicit size_t to Eigen::Index conversions
+target_compile_options(
+  testab PRIVATE "-Wno-sign-conversion") # We have a lot of implicit size_t to
+                                         # Eigen::Index conversions

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,8 +24,10 @@ set(TESTS eiquadprog-basic eiquadprog-fast eiquadprog-rt eiquadprog-both
 foreach(test ${TESTS})
   add_unit_test(${test} ${test}.cpp)
   target_link_libraries(${test} ${PROJECT_NAME} Boost::unit_test_framework)
+  target_compile_options(${test} PRIVATE "-Wno-sign-conversion")  # We have a lot of implicit size_t to Eigen::Index conversions
 endforeach(test ${TESTS})
 
 add_library(testab SHARED TestA.cpp TestB.cpp)
 target_link_libraries(testab ${PROJECT_NAME})
 target_link_libraries(test-integration testab)
+target_compile_options(testab PRIVATE "-Wno-sign-conversion")  # We have a lot of implicit size_t to Eigen::Index conversions


### PR DESCRIPTION
There are a lot of implicit std::size_t to Eigen::Index (long) conversions. This deactivates the warnings for now since fixing them directly might be quite verbose (by explicit casting everywhere)